### PR TITLE
Fix syntax error in docker-entrypoint.sh

### DIFF
--- a/rootfs/docker-entrypoint.sh
+++ b/rootfs/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 usage() {
    echo "$0 features:" >&2
    echo '  - If set, use $SSODOMAIN environment variable to set domain name' >&2
-   echo '  - setup llng-fastcgi-server envs and dirs
+   echo '  - setup llng-fastcgi-server envs and dirs' >&2
 }
 
 if [ "$1" = '--help' ]; then


### PR DESCRIPTION
/docker-entrypoint.sh: line 9: unexpected EOF while looking for matching `''
/docker-entrypoint.sh: line 33: syntax error: unexpected end of file