### PR TITLE
Ensure all map keys are strings

### DIFF
--- a/pkg/lemonldapng/config/file_test.go
+++ b/pkg/lemonldapng/config/file_test.go
@@ -81,6 +81,19 @@ func TestOverrides(t *testing.T) {
 	overrides := make(map[string]interface{})
 	overrides = map[string]interface{}{
 		"domain": "example.org",
+		"exportedHeaders": map[interface{}]interface{}{
+			"foo.example.org": map[interface{}]interface{}{
+				"CAS-User": "$uid",
+			},
+		},
+		"locationRules": map[interface{}]interface{}{
+			"foo.example.org": map[interface{}]interface{}{
+				"default": "$uid eq 'dwho'",
+			},
+		},
+		"arrayOptions": []interface{}{
+			"value",
+		},
 	}
 
 	config.SetOverrides(overrides)


### PR DESCRIPTION
YAML also allows booleans or integers as hash keys. In JSON and LemonLDAP::NG, we want strings.

See https://github.com/go-yaml/yaml/issues/139 for details