### PR TITLE
Change the ConfigMap format and move LemonLDAP::NG keys just below Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See also [LemonLDAP::NG documentation](https://www.lemonldap-ng.org/documentatio
 
 A config map can be used to override lmConf-1.js parameters.
 
-YAML or JSON are supported:
+Any key suffixed by `.yaml` will be parsed accordingly:
 
 ```yaml
 kind: ConfigMap
@@ -83,8 +83,15 @@ metadata:
   name: lemonldap-ng-configuration
   namespace: ingress-nginx
 data:
-  lmConf.js: |
-    domain: example.org
+  domain: example.org
+  globalStorage: Apache::Session::Browseable::Postgres # Default Apache::Session::File
+  globalStorageOptions.yaml: |
+    DataSource: dbi:Pg:dbname=sessions;host=10.2.3.1
+    UserName: lemonldapng
+    Password: mysuperpassword
+    TableName: sessions
+    Commit: 1
+    Index: _whatToTrace ipAddr
 ```
 
 This is the most difficult part of LemonLDAP::NG configuration.

--- a/deploy/llng-configmap.yaml
+++ b/deploy/llng-configmap.yaml
@@ -6,32 +6,31 @@ metadata:
   labels:
     app: ingress-nginx
 data:
-  lmConf.js: |
-    # SSO Cookie
-    domain: example.org
-    cookieName: lemonldap
-    securedCookie: 0 # 0=unsecuredCookie, 1=securedCookie, 2=doubleCookie, 3=doubleCookieForSingleSession
-    # cda: 1 # for Cross domain authentication
-    
-    # Portal URL
-    portal: http://auth.example.org/
-    mailUrl : http://auth.example.org/mail.pl
-    registerUrl : http://auth.example.org/register.pl
-    # https: 1 # recommended, to force HTTPs
-    
-    # Authentification, user and password backends
-    # authentication: LDAP # Default Demo
-    # userDB: LDAP # Default Demo
-    # passwordDB: LDAP # Default Demo
-    # ldapServer: ldap://ldap.example.org
-    # ldapBase: dc=example,dc=org
-    
-    # Session database
-    # globalStorage: Apache::Session::Browseable::Postgres # Default Apache::Session::File
-    # globalStorageOptions:
-    #   DataSource: dbi:Pg:dbname=sessions;host=10.2.3.1
-    #   UserName: lemonldapng
-    #   Password: mysuperpassword
-    #   TableName: sessions
-    #   Commit: 1
-    #   Index: _whatToTrace ipAddr
+  # SSO Cookie
+  domain: example.org
+  cookieName: lemonldap
+  securedCookie: "0" # 0=unsecuredCookie, 1=securedCookie, 2=doubleCookie, 3=doubleCookieForSingleSession
+  # cda: "1" # for Cross domain authentication
+
+  # Portal URL
+  portal: http://auth.example.org/
+  mailUrl : http://auth.example.org/mail.pl
+  registerUrl : http://auth.example.org/register.pl
+  # https: "1" # recommended, to force HTTPs
+
+  # Authentification, user and password backends
+  # authentication: LDAP # Default Demo
+  # userDB: LDAP # Default Demo
+  # passwordDB: LDAP # Default Demo
+  # ldapServer: ldap://ldap.example.org
+  # ldapBase: dc=example,dc=org
+
+  # Session database
+  # globalStorage: Apache::Session::Browseable::Postgres # Default Apache::Session::File
+  # globalStorageOptions.yaml: |
+  #   DataSource: dbi:Pg:dbname=sessions;host=10.2.3.1
+  #   UserName: lemonldapng
+  #   Password: mysuperpassword
+  #   TableName: sessions
+  #   Commit: "1"
+  #   Index: _whatToTrace ipAddr

--- a/test/e2e/settings/portal.go
+++ b/test/e2e/settings/portal.go
@@ -44,8 +44,8 @@ var _ = framework.IngressNginxDescribe("Portal URL", func() {
 	It("should respect portal parameter", func() {
 		host := "goto-portal.example.com"
 
-		setting := "lmConf.js"
-		oldValue := updateConfigmap(setting, "portal: http://portal.example.com/", f.KubeClientSet)
+		setting := "portal"
+		oldValue := updateConfigmap(setting, "http://portal.example.com/", f.KubeClientSet)
 		defer updateConfigmap(setting, oldValue, f.KubeClientSet)
 
 		bi := buildIngress(host, f.Namespace.Name)


### PR DESCRIPTION
Rationale: the level 1 configs are easier to modify using the k8s API.

Fixes #56.