### PR TITLE
Ensure stringifyYAMLMapKeys converts root keys

### DIFF
--- a/internal/lemonldapng/config/file.go
+++ b/internal/lemonldapng/config/file.go
@@ -174,6 +174,11 @@ func stringifyYAMLMapKeys(in interface{}) interface{} {
 			res[fmt.Sprintf("%v", k)] = stringifyYAMLMapKeys(v)
 		}
 		return res
+	case map[string]interface{}:
+		for k, v := range in {
+			in[k] = stringifyYAMLMapKeys(v)
+		}
+		return in
 	default:
 		return in
 	}


### PR DESCRIPTION
Before this commit, stringifyYAMLMapKeys would ne stringify overrides (since #59).